### PR TITLE
cors config changes for IE support and caching

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -36,7 +36,9 @@ func Server(keystone identity.Identity, storage storage.Storage, configdb config
 	//start HTTP server with CORS support
 	util.LogInfo("listening on " + viper.GetString("API.ListenAddress"))
 	c := cors.New(cors.Options{
-		AllowedHeaders: []string{"X-Auth-Token"},
+		AllowedHeaders: []string{"X-Auth-Token", "Content-Type", "Accept"},
+		AllowedMethods: []string{"GET", "HEAD"},
+		MaxAge: 600,
 	})
 	handler := c.Handler(mainRouter)
 	return http.ListenAndServe(viper.GetString("API.ListenAddress"), handler)


### PR DESCRIPTION
This adds additional allowed headers to the CORS response (otherwise IE won't accept it). Also added caching for the preflight request for 10 minutes (so the browser doesn't do the preflight check for every request).