### PR TITLE
remove filling details with token context

### DIFF
--- a/pkg/api/token.go
+++ b/pkg/api/token.go
@@ -59,14 +59,10 @@ func (p *v1Provider) CheckToken(r *http.Request) *Token {
 		}
 	}
 	t.context.Request = mux.Vars(r)
-	if r.FormValue("domain_id") == "" {
-		t.context.Request["domain_id"] = t.context.Auth["domain_id"]
-	} else {
+	if r.FormValue("domain_id") != "" {
 		t.context.Request["domain_id"] = r.FormValue("domain_id")
 	}
-	if r.FormValue("project_id") == "" {
-		t.context.Request["project_id"] = t.context.Auth["project_id"]
-	} else {
+	if r.FormValue("project_id") != "" {
 		t.context.Request["project_id"] = r.FormValue("project_id")
 	}
 	return t


### PR DESCRIPTION
This is filling in both the project and domain id, and we're only accepting one or the other. This removes a check that would send an incorrect allow. 