### PR TITLE
pkg/cadf: add attributes for name enrichment to type Resource

### DIFF
--- a/pkg/cadf/event.go
+++ b/pkg/cadf/event.go
@@ -74,6 +74,11 @@ type Resource struct {
 	// project_id and domain_id are OpenStack extensions (introduced by Keystone and keystone(audit)middleware)
 	ProjectID string `json:"project_id,omitempty"`
 	DomainID  string `json:"domain_id,omitempty"`
+	// project_name, project_domain_name, domain_name are Hermes extensions for initiator resources only (they
+	// all refer to the token scope; the initiating user's original domain is described by "domain")
+	ProjectName       string `json:"project_name,omitempty"`
+	ProjectDomainName string `json:"project_domain_name,omitempty"`
+	DomainName        string `json:"domain_name,omitempty"`
 }
 
 // Reason contains HTTP Code and Type, and is optional in the CADF spec
@@ -160,12 +165,18 @@ func (p EventParams) NewEvent() Event {
 			ReasonCode: strconv.Itoa(p.ReasonCode),
 		},
 		Initiator: Resource{
-			TypeURI:   "service/security/account/user",
-			Name:      p.Token.Context.Auth["user_name"],
-			ID:        p.Token.Context.Auth["user_id"],
-			Domain:    p.Token.Context.Auth["domain_name"],
-			DomainID:  p.Token.Context.Auth["domain_id"],
-			ProjectID: p.Token.Context.Auth["project_id"],
+			TypeURI: "service/security/account/user",
+			//user attributes
+			Name:   p.Token.Context.Auth["user_name"],
+			ID:     p.Token.Context.Auth["user_id"],
+			Domain: p.Token.Context.Auth["user_domain_name"],
+			//token scope attributes
+			DomainID:          p.Token.Context.Auth["domain_id"],
+			DomainName:        p.Token.Context.Auth["domain_name"],
+			ProjectID:         p.Token.Context.Auth["project_id"],
+			ProjectName:       p.Token.Context.Auth["project_name"],
+			ProjectDomainName: p.Token.Context.Auth["project_domain_name"],
+			//other attributes
 			Host: &Host{
 				Address: StripPort(p.Request.RemoteAddr),
 				Agent:   p.Request.Header.Get("User-Agent"),


### PR DESCRIPTION
We want to have project/domain names on Initiator resources in a standard way. Since all other Go-based services rely on `package cadf` when generating structured events, `type Resource` needs to support the respective fields.

While making this change, I realized that `AuditParameters.NewEvent()` in this package deviates from github.com/sapcc/go-bits/audittools in the meaning of Initiator.Domain: In this package, Initiator.Domain is set to the domain from the token scope (or empty for project-scoped tokens), whereas audittools sets Initiator.Domain to the name of the user's domain.

The CADF standard (cf. [link](https://www.dmtf.org/sites/default/files/standards/documents/DSP0262_1.0.0.pdf), page 101) describes the "domain" attribute for resources as "the optional name of the domain that qualifies the name of the resource". Since "the resource" is the initiating user in this case, this supports audittools' interpretation. I therefore changed NewEvent() in this package to use the same interpretation. Since there are no users of NewEvent() across sapcc projects right now (at least as far as GitHub Code Search can tell), this should be a low-impact change.