### PR TITLE
feat: Add index mapping for Export events feature

### DIFF
--- a/etc/events_export_index.json
+++ b/etc/events_export_index.json
@@ -1,0 +1,38 @@
+PUT /events/export
+{
+  "mappings": {
+    "properties": {
+      "project_id": {
+        "type": "keyword"
+      },
+      "enabled": {
+        "type": "boolean"
+      },
+      "retention_period": {
+        "type": "integer"
+      },
+      "bucket_name": {
+        "type": "keyword"
+      },
+      "last_run_time": {
+        "type": "date"
+      },
+      "filters": {
+        "properties": {
+          "event_types": {
+            "type": "keyword"
+          },
+          "resource_types": {
+            "type": "keyword"
+          },
+          "exclude_event_types": {
+            "type": "keyword"
+          },
+          "exclude_resource_types": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This commit introduces a new index mapping definition for the Export events feature. 

The mapping includes fields for project_id, enabled, retention_period, bucket_name, last_run_time, and various filters such as event_types, resource_types, exclude_event_types, and exclude_resource_types. 

This setup will support config options for customers to choose when exporting audit event data from Hermes.