### PR TITLE
increase attribute limit from 50 to 10000 which is max supported by Opensearch

### DIFF
--- a/docs/users/hermes-v1-reference.md
+++ b/docs/users/hermes-v1-reference.md
@@ -212,7 +212,7 @@ returns
 | **Name** | **Type** | **Description** | **Default** |
 | --- | --- | --- | --- | 
 | max_depth | integer | max. depth / level of detail of hierarchical values | infinity / unlimited |
-| limit | integer | limit of values returned | 50 | 
+| limit | integer | limit of values returned | 10000 | 
 
 ### Hierarchical Values
 

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -301,9 +301,9 @@ func (p *v1Provider) GetAttributes(res http.ResponseWriter, req *http.Request) {
 	maxdepth, _ := strconv.ParseUint(req.FormValue("max_depth"), 10, 32) //nolint:errcheck
 	limit, _ := strconv.ParseUint(req.FormValue("limit"), 10, 32)        //nolint:errcheck
 
-	// Default Limit of 50 if not specified by queryparam
+	// Default Limit of 10000 if not specified by queryparam, which is the max opensearch supports.
 	if limit == 0 {
-		limit = 50
+		limit = 10000
 	}
 
 	logg.Debug("api.GetAttributes: Create filter")


### PR DESCRIPTION
Straight forward, the limit is far too small. it's cutting off events in the attributes call in projects