### PR TITLE
Setup reuse with license info

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 version: 2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 SAP SE
+#
+# SPDX-License-Identifier: Apache-2.0
+
 FROM golang:1.24.3-alpine3.21 AS builder
 
 RUN apk add --no-cache --no-progress ca-certificates gcc git make musl-dev

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -31,3 +31,26 @@ renovate:
   enabled: true
   assignees:
     - notque
+
+reuse:
+  annotations:
+    # Image files
+    - paths:
+        - ".github/assets/hermes.png"
+        - "AppStructure.png"
+      SPDX-FileCopyrightText: "SAP SE"
+      SPDX-License-Identifier: "Apache-2.0"
+    # JSON config/policy/example/fixture files
+    - paths:
+        - "docs/example-policy.json"
+        - "etc/permissive-policy.json"
+        - "etc/policy.json"
+        - "pkg/api/fixtures/*.json" # Glob for fixtures
+        - "pkg/test/policy.json"
+      SPDX-FileCopyrightText: "SAP SE"
+      SPDX-License-Identifier: "Apache-2.0"
+    # Add go.sum based on majewsky's previous comment
+    - paths:
+        - "go.sum"
+      SPDX-FileCopyrightText: "SAP SE"
+      SPDX-License-Identifier: "Apache-2.0"

--- a/Makefile.maker.yaml
+++ b/Makefile.maker.yaml
@@ -38,19 +38,13 @@ reuse:
     - paths:
         - ".github/assets/hermes.png"
         - "AppStructure.png"
-      SPDX-FileCopyrightText: "SAP SE"
-      SPDX-License-Identifier: "Apache-2.0"
-    # JSON config/policy/example/fixture files
-    - paths:
         - "docs/example-policy.json"
         - "etc/permissive-policy.json"
         - "etc/policy.json"
         - "pkg/api/fixtures/*.json" # Glob for fixtures
         - "pkg/test/policy.json"
-      SPDX-FileCopyrightText: "SAP SE"
-      SPDX-License-Identifier: "Apache-2.0"
-    # Add go.sum based on majewsky's previous comment
-    - paths:
         - "go.sum"
-      SPDX-FileCopyrightText: "SAP SE"
-      SPDX-License-Identifier: "Apache-2.0"
+        - "build/.empty.txt"
+        - "etc/*.conf"
+      SPDX-FileCopyrightText: SAP SE
+      SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 <!-- Logo and Title -->
 <div align="center">
   <img src=".github/assets/hermes.png" alt="Hermes Logo" width="250"/>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -16,3 +16,29 @@ path = [
 ]
 SPDX-FileCopyrightText = "SAP SE"
 SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+  ".github/assets/hermes.png",
+  "AppStructure.png",
+]
+SPDX-FileCopyrightText = "SAP SE"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+  "docs/example-policy.json",
+  "etc/permissive-policy.json",
+  "etc/policy.json",
+  "pkg/api/fixtures/*.json",
+  "pkg/test/policy.json",
+]
+SPDX-FileCopyrightText = "SAP SE"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
+path = [
+  "go.sum",
+]
+SPDX-FileCopyrightText = "SAP SE"
+SPDX-License-Identifier = "Apache-2.0"

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -21,24 +21,14 @@ SPDX-License-Identifier = "Apache-2.0"
 path = [
   ".github/assets/hermes.png",
   "AppStructure.png",
-]
-SPDX-FileCopyrightText = "SAP SE"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = [
   "docs/example-policy.json",
   "etc/permissive-policy.json",
   "etc/policy.json",
   "pkg/api/fixtures/*.json",
   "pkg/test/policy.json",
-]
-SPDX-FileCopyrightText = "SAP SE"
-SPDX-License-Identifier = "Apache-2.0"
-
-[[annotations]]
-path = [
   "go.sum",
+  "build/.empty.txt",
+  "etc/*.conf",
 ]
 SPDX-FileCopyrightText = "SAP SE"
 SPDX-License-Identifier = "Apache-2.0"

--- a/docs/design/001-fundamentals.md
+++ b/docs/design/001-fundamentals.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Fundamental requirements
 
 - Expose OpenStack-like REST API

--- a/docs/design/002-to-do.md
+++ b/docs/design/002-to-do.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 * Replacement of Logstash for transferring events from RabbitMQ to 
     * If we wish to configure the service via API, it would be significantly easier to have an API against which to edit the configuration. Logstash doesn't enable this, using config files. Those config files can be live changed while the service runs, but this isn't ideal. In later versions of ElasticSearch/Logstash there is an API for configuration changes, but it doesn't enable the granular changes we require.
     * We want to send all events to OpenStack Swift, as well as ElasticSearch. Logstash can possibly use this with the s3 api, however if we want to do anything like putting events into ProjectID buckets, we're going to be unable to do that.

--- a/docs/design/003-Export-Events.md
+++ b/docs/design/003-Export-Events.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # ExportEvents Feature Design Document
 
 ## Overview

--- a/docs/operators/config.md
+++ b/docs/operators/config.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Configuration Guide
 
 Hermes is configured using a TOML config file that is by default located in `etc/hermes/hermes.conf`.

--- a/docs/operators/operators-guide.md
+++ b/docs/operators/operators-guide.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hermes Operators Guide
 
 This guide describes how to setup OpenStack Auditing with Hermes.

--- a/docs/users/api-example.md
+++ b/docs/users/api-example.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Using the Hermes API
 
 The Hermes API allows you to access audit events on a tenant basis, providing detailed information about each event, including the 7 “W”s of audit: What, When, Who, FromWhere, OnWhat, Where, ToWhere. This guide will walk you through the process of getting a token, finding the Hermes endpoint, and using the API.

--- a/docs/users/hermes-v1-reference.md
+++ b/docs/users/hermes-v1-reference.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Hermes v1 API Reference
 
 The URLs indicated in the headers of each section are relative to the endpoint URL advertised in the Keystone catalog 

--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -1,3 +1,9 @@
+<!--
+SPDX-FileCopyrightText: 2025 SAP SE
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Getting Started with Hermes
 
 Hermes is an audit trail service for OpenStack that enables easy access to audit events on a tenant basis. With Hermes, you can view project-level audit events through an API or as an optional module in the OpenStack dashboard, Elektra.

--- a/main.go
+++ b/main.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package main
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package api
 

--- a/pkg/hermes/events.go
+++ b/pkg/hermes/events.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package hermes
 

--- a/pkg/hermes/events_test.go
+++ b/pkg/hermes/events_test.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package hermes
 

--- a/pkg/identity/keystone.go
+++ b/pkg/identity/keystone.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package identity
 

--- a/pkg/policy/policy_test.go
+++ b/pkg/policy/policy_test.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package policy
 

--- a/pkg/storage/elasticsearch.go
+++ b/pkg/storage/elasticsearch.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/storage/mock.go
+++ b/pkg/storage/mock.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/storage/mock_test.go
+++ b/pkg/storage/mock_test.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/storage/util.go
+++ b/pkg/storage/util.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/storage/util_test.go
+++ b/pkg/storage/util_test.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package storage
 

--- a/pkg/test/http.go
+++ b/pkg/test/http.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/pkg/util/hacks.go
+++ b/pkg/util/hacks.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package util
 

--- a/pkg/util/load_policy.go
+++ b/pkg/util/load_policy.go
@@ -1,21 +1,7 @@
-/*******************************************************************************
-*
-* Copyright 2022 SAP SE
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You should have received a copy of the License along with this
-* program. If not, you may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-*******************************************************************************/
+// Copyright 2022 SAP SE
+// SPDX-FileCopyrightText: 2025 SAP SE
+//
+// SPDX-License-Identifier: Apache-2.0
 
 package util
 


### PR DESCRIPTION
This pull request primarily focuses on adding SPDX license headers to various files across the project, ensuring compliance with licensing requirements. I used reuse annotate to generate the changes. It includes the full text of the Apache 2.0 license.

### Licensing Updates:
* Added SPDX license headers to multiple files, including `.dockerignore`, `Dockerfile`, `README.md`, and various documentation files, specifying copyright ownership by SAP SE and licensing under Apache 2.0. [[1]](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R1-R4) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R4) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1-R6) [[4]](diffhunk://#diff-4f77669d092c0afc2b499338486cebef215101b2af94465ed9d1c019de23ff5aR1-R6) [[5]](diffhunk://#diff-43bbfc668e04659479d97dd7c4a122855c3055ca3dd55df96876dbc11e2bf320R1-R6)

* Included the full text of the Apache 2.0 license in `LICENSES/Apache-2.0.txt`.