### PR TITLE
Removes backup reviewers from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 # @notque = lead developer
 # @notandy = timezone help
 # @Kuckkuck @viennaa @richardtief @olandr @joluc = observability team
-# @majewsky @SuperSandro2000 = backup reviewers
 # @sapcc/cc_github_managers_approval = management
-* @notque @notandy @Kuckkuck @viennaa @richardtief @olandr @joluc @majewsky @SuperSandro2000 @sapcc/cc_github_managers_approval
+* @notque @notandy @Kuckkuck @viennaa @richardtief @olandr @joluc @sapcc/cc_github_managers_approval


### PR DESCRIPTION
I was told they are unavailable for requests, so I am just spamming them.