### PR TITLE
fix: use pointer receivers on OpenSearch to prevent per-request client re-init

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func configuredStorageDriver() storage.Storage {
 	driverName := viper.GetString("hermes.storage_driver")
 	switch driverName {
 	case "opensearch":
-		return openSearchStorage
+		return &openSearchStorage
 	case "mock":
 		return mockStorage
 	default:

--- a/pkg/storage/opensearch.go
+++ b/pkg/storage/opensearch.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opensearch-project/opensearch-go/v4"
@@ -25,13 +26,11 @@ import (
 // OpenSearch contains an opensearchapi.Client we pass around after init.
 type OpenSearch struct {
 	osClient *opensearchapi.Client
+	initOnce sync.Once
 }
 
 func (os *OpenSearch) client() *opensearchapi.Client {
-	// Lazy initialisation - don't connect to OpenSearch until we need to
-	if os.osClient == nil {
-		os.init()
-	}
+	os.initOnce.Do(os.init)
 	return os.osClient
 }
 
@@ -189,7 +188,7 @@ func buildBoolQuery(filter *EventFilter, tenantID string) map[string]any {
 }
 
 // GetEvents grabs events for a given tenantID with filtering.
-func (os OpenSearch) GetEvents(ctx context.Context, filter *EventFilter, tenantID string) ([]*cadf.Event, int, error) {
+func (os *OpenSearch) GetEvents(ctx context.Context, filter *EventFilter, tenantID string) ([]*cadf.Event, int, error) {
 	// Validate tenant ID
 	if err := validateTenantID(tenantID); err != nil {
 		return nil, 0, fmt.Errorf("invalid tenant ID: %w", err)
@@ -303,7 +302,7 @@ func buildGetEventQuery(eventID, tenantID string) map[string]any {
 }
 
 // GetEvent Returns EventDetail for a single event.
-func (os OpenSearch) GetEvent(ctx context.Context, eventID, tenantID string) (*cadf.Event, error) {
+func (os *OpenSearch) GetEvent(ctx context.Context, eventID, tenantID string) (*cadf.Event, error) {
 	// Validate tenant ID
 	if err := validateTenantID(tenantID); err != nil {
 		return nil, fmt.Errorf("invalid tenant ID: %w", err)
@@ -374,7 +373,7 @@ func buildGetAttributesQuery(osName string, limit uint, tenantID string) map[str
 }
 
 // GetAttributes Return all unique attributes available for filtering
-func (os OpenSearch) GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string) ([]string, error) {
+func (os *OpenSearch) GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string) ([]string, error) {
 	// Validate tenant ID
 	if err := validateTenantID(tenantID); err != nil {
 		return nil, fmt.Errorf("invalid tenant ID: %w", err)
@@ -462,7 +461,7 @@ func (os OpenSearch) GetAttributes(ctx context.Context, filter *AttributeFilter,
 }
 
 // MaxLimit grabs the configured maxlimit for results
-func (os OpenSearch) MaxLimit() uint {
+func (os *OpenSearch) MaxLimit() uint {
 	maxLimit := viper.GetInt("opensearch.max_result_window")
 	if maxLimit < 0 {
 		return 0


### PR DESCRIPTION
## Summary

- **Fix data race and resource leak**: OpenSearch struct methods used value receivers, causing the `storage.Storage` interface to store a copy. Every HTTP request saw `osClient` as nil and created a new OpenSearch client + HTTP transport, defeating connection pooling and leaking goroutines.
- **Add `sync.Once`** for thread-safe lazy initialization, replacing the unsafe nil-check pattern.
- **Return pointer** from `configuredStorageDriver()` so all requests share the same client instance.

### Root Cause

```go
// BEFORE: value receiver — interface stores a copy, osClient always nil
func (os OpenSearch) GetEvents(...) { os.client().Search(...) }

// AFTER: pointer receiver — interface stores pointer, osClient shared
func (os *OpenSearch) GetEvents(...) { os.client().Search(...) }
```

### Impact

| Before | After |
|--------|-------|
| New OpenSearch client per request | Single shared client |
| New HTTP transport per request | Shared connection pool (MaxIdleConnsPerHost: 10) |
| Goroutine leak (health checks per client) | One set of background goroutines |
| File descriptor exhaustion under load | Bounded connections |

### Validation

- `go build ./...` — compiles clean
- `go test ./...` — all tests pass
- Verified against [opensearch-go docs](https://github.com/opensearch-project/opensearch-go/blob/main/USER_GUIDE.md): client is thread-safe, should be created once and shared
- Independent code review agent: **PASS**

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Verified `*OpenSearch` satisfies `storage.Storage` interface
- [x] Confirmed `Mock` storage (value receivers, stateless) is unaffected
- [ ] Manual verification under concurrent load in staging