### PR TITLE
fix: fail fast on startup misconfiguration instead of deferred panics

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/sapcc/go-bits/gopherpolicy"
@@ -40,7 +41,7 @@ func main() {
 	setDefaultConfig()
 	readConfig(configPath)
 
-	if viper.GetString("hermes.keystone_driver") == "keystone" && viper.GetString("hermes.PolicyFilePath") == "" {
+	if viper.GetString("hermes.keystone_driver") == "keystone" && strings.TrimSpace(viper.GetString("hermes.PolicyFilePath")) == "" {
 		logg.Fatal("hermes.PolicyFilePath must be set when using the keystone driver")
 	}
 

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/logg"
@@ -38,6 +39,11 @@ func main() {
 
 	setDefaultConfig()
 	readConfig(configPath)
+
+	if viper.GetString("hermes.keystone_driver") == "keystone" && viper.GetString("hermes.PolicyFilePath") == "" {
+		logg.Fatal("hermes.PolicyFilePath must be set when using the keystone driver")
+	}
+
 	keystoneDriver := configuredKeystoneDriver()
 	storageDriver := configuredStorageDriver()
 
@@ -96,12 +102,14 @@ func configuredKeystoneDriver() gopherpolicy.Validator {
 	driverName := viper.GetString("hermes.keystone_driver")
 	switch driverName {
 	case "keystone":
-		return must.Return(identity.NewTokenValidator(context.TODO()))
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		return must.Return(identity.NewTokenValidator(ctx))
 	case "mock":
 		return mock.NewValidator(mock.NewEnforcer(), nil)
 	default:
-		logg.Error("Couldn't match a keystone driver for configured value \"%s\"", driverName)
-		return nil
+		logg.Fatal("unknown keystone_driver %q", driverName)
+		return nil // unreachable
 	}
 }
 
@@ -116,7 +124,7 @@ func configuredStorageDriver() storage.Storage {
 	case "mock":
 		return mockStorage
 	default:
-		logg.Error("Couldn't match a storage driver for configured value \"%s\"", driverName)
-		return nil
+		logg.Fatal("unknown storage_driver %q", driverName)
+		return nil // unreachable
 	}
 }


### PR DESCRIPTION
## Summary

Three startup reliability fixes in `main.go`:

- **C2 — Nil driver panic**: Unknown `keystone_driver` or `storage_driver` values now call `logg.Fatal()` instead of logging an error and returning `nil`. Previously the server started with nil drivers and panicked on first request.
- **H4 — Silent auth bypass**: Validate that `hermes.PolicyFilePath` is non-empty (with whitespace trimming) when using the keystone driver. An empty path silently disables authorization enforcement.
- **H5 — Infinite hang on Keystone**: Replace `context.TODO()` with `context.WithTimeout(30s)` for Keystone authentication. If Keystone is unreachable at startup, the process now exits after 30 seconds instead of hanging indefinitely.

### Before → After

| Scenario | Before | After |
|----------|--------|-------|
| Unknown driver name | Logs error, starts with nil → panic on 1st request | `logg.Fatal` exits immediately |
| Empty PolicyFilePath | Silently disables all authorization | `logg.Fatal` exits with clear message |
| Keystone unreachable | Hangs forever | Times out after 30s, exits |

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./...` all tests pass
- [x] Mock driver path unaffected (no PolicyFilePath validation for mock)
- [x] Code review: PASS (whitespace edge case caught and fixed)
- [ ] Manual: verify `logg.Fatal` output format with invalid driver name
- [ ] Manual: verify timeout behavior with unreachable Keystone