### PR TITLE
api: cap /v1/attributes limit at MaxLimit

### DIFF
--- a/docs/users/hermez-v1-reference.md
+++ b/docs/users/hermez-v1-reference.md
@@ -218,7 +218,7 @@ returns
 | **Name** | **Type** | **Description** | **Default** |
 | --- | --- | --- | --- | 
 | max_depth | integer | max. depth / level of detail of hierarchical values | infinity / unlimited |
-| limit | integer | limit of values returned | 10000 | 
+| limit | integer | limit of values returned (capped at the server's configured maximum; requests above the cap return HTTP 400) | 10000 | 
 
 ### Hierarchical Values
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -70,7 +70,8 @@ func Test_API(t *testing.T) {
 		{"Metadata", "GET", "/v1/", http.StatusOK, "fixtures/api-metadata.json"},
 		{"EventDetails", "GET", "/v1/events/7be6c4ff-b761-5f1f-b234-f5d41616c2cd", http.StatusOK, "fixtures/event-details.json"},
 		{"EventList", "GET", "/v1/events?event_type=identity.project.deleted&offset=10", http.StatusOK, "fixtures/event-list.json"},
-		{"Attributes", "GET", "/v1/attributes/resource_type", http.StatusOK, "fixtures/attributes.json"},
+		{"Attributes", "GET", "/v1/attributes/resource_type?limit=10", http.StatusOK, "fixtures/attributes.json"},
+		{"AttributesLimitExceedsMax", "GET", "/v1/attributes/action?limit=99999", http.StatusBadRequest, ""},
 		{"InvalidEventID", "GET", "/v1/events/invalid-uuid", http.StatusBadRequest, ""},
 	}
 

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -337,6 +337,13 @@ func (p *v1Provider) GetAttributes(res http.ResponseWriter, req *http.Request) {
 		limit = 10000
 	}
 
+	// Reject limits above the configured storage maximum, matching the
+	// offset+limit check applied to GET /v1/events in hermes.storageFilter.
+	if maxLimit := p.storage.MaxLimit(); uint(limit) > maxLimit {
+		http.Error(res, fmt.Sprintf("limit %d exceeds the maximum of %d", limit, maxLimit), http.StatusBadRequest)
+		return
+	}
+
 	logg.Debug("api.GetAttributes: Create filter")
 	filter := hermes.AttributeFilter{
 		QueryName: queryName,


### PR DESCRIPTION
## What this does
Caps the `limit` query parameter on `GET /v1/attributes/{attribute_name}`
at `storage.MaxLimit()`. Requests above the cap return HTTP 400 instead
of being forwarded to OpenSearch.

## Why
Aligns the attributes endpoint with the offset+limit check that
`pkg/hermes.storageFilter` already applies to `GET /v1/events`. Same
storage backend, same upper bound — consistent behaviour and a clearer
error than the backend would produce.

## How to verify
- `make check` passes, including the new `AttributesLimitExceedsMax`
  table entry in `pkg/api/api_test.go` that exercises
  `GET /v1/attributes/action?limit=99999` and asserts HTTP 400.