### PR TITLE
storage: constrain attribute_name to documented values

### DIFF
--- a/docs/users/hermez-v1-reference.md
+++ b/docs/users/hermez-v1-reference.md
@@ -203,6 +203,10 @@ event, e.g.:
 Returns the unique values of a given attribute, so that you can e.g. have users select from them. Scoped to the 
 OpenStack token.
 
+Valid values for `attribute_name`: `time`, `action`, `outcome`, `request_path`, `observer_id`, `observer_type`,
+`target_id`, `target_type`, `resource_type` (alias for `target_type`), `initiator_id`, `initiator_type`,
+`initiator_name`. Unknown names return HTTP 400.
+
 `GET /v1/attributes/action`
 
 returns

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -71,6 +71,8 @@ func Test_API(t *testing.T) {
 		{"EventDetails", "GET", "/v1/events/7be6c4ff-b761-5f1f-b234-f5d41616c2cd", http.StatusOK, "fixtures/event-details.json"},
 		{"EventList", "GET", "/v1/events?event_type=identity.project.deleted&offset=10", http.StatusOK, "fixtures/event-list.json"},
 		{"Attributes", "GET", "/v1/attributes/resource_type", http.StatusOK, "fixtures/attributes.json"},
+		{"AttributesKnownName", "GET", "/v1/attributes/action", http.StatusOK, "fixtures/attributes.json"},
+		{"AttributesUnknownName", "GET", "/v1/attributes/observer.id.keyword", http.StatusBadRequest, ""},
 		{"InvalidEventID", "GET", "/v1/events/invalid-uuid", http.StatusBadRequest, ""},
 	}
 

--- a/pkg/api/events.go
+++ b/pkg/api/events.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sapcc/go-bits/respondwith"
 
 	"github.com/sapcc/hermes/pkg/hermes"
+	"github.com/sapcc/hermes/pkg/storage"
 )
 
 // EventList is the model for JSON returned by the ListEvents API call
@@ -350,6 +351,11 @@ func (p *v1Provider) GetAttributes(res http.ResponseWriter, req *http.Request) {
 	}
 
 	attribute, err := hermes.GetAttributes(req.Context(), &filter, indexID, p.storage)
+
+	if errors.Is(err, storage.ErrUnknownAttributeName) {
+		http.Error(res, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	if respondwith.ErrorText(res, err) {
 		logg.Error("could not get attributes from Storage: %s", err)

--- a/pkg/hermes/events_test.go
+++ b/pkg/hermes/events_test.go
@@ -43,7 +43,7 @@ func Test_GetEvents(t *testing.T) {
 }
 
 func Test_GetAttributes(t *testing.T) {
-	attributes, err := GetAttributes(context.Background(), &AttributeFilter{}, "", storage.Mock{})
+	attributes, err := GetAttributes(context.Background(), &AttributeFilter{QueryName: "action"}, "", storage.Mock{})
 	require.Nil(t, err)
 	require.NotNil(t, attributes)
 	assert.Equal(t, len(attributes), 6)

--- a/pkg/storage/interface.go
+++ b/pkg/storage/interface.go
@@ -20,6 +20,10 @@ var (
 	ErrInvalidTenantID = errors.New("tenant ID 'unavailable' is not valid for queries")
 )
 
+// ErrUnknownAttributeName is returned by GetAttributes when the requested
+// attribute_name is not in the documented public set (CADFFieldMapping keys).
+var ErrUnknownAttributeName = errors.New("unknown attribute_name")
+
 // Status contains Prometheus status strings
 // TODO: Determine if we want a similar setup for OpenSearch.
 type Status string

--- a/pkg/storage/mock.go
+++ b/pkg/storage/mock.go
@@ -44,6 +44,9 @@ func (m Mock) MaxLimit() uint {
 
 // GetAttributes Mock
 func (m Mock) GetAttributes(ctx context.Context, filter *AttributeFilter, tenantID string) ([]string, error) {
+	if _, ok := CADFFieldMapping[filter.QueryName]; !ok {
+		return nil, ErrUnknownAttributeName
+	}
 	var parsedAttribute []string
 	err := json.Unmarshal(mockAttributes, &parsedAttribute)
 	return parsedAttribute, err

--- a/pkg/storage/mock_test.go
+++ b/pkg/storage/mock_test.go
@@ -51,7 +51,7 @@ func Test_MockStorage_Events(t *testing.T) {
 }
 
 func Test_MockStorage__Attributes(t *testing.T) {
-	attributesList, err := Mock{}.GetAttributes(context.Background(), &AttributeFilter{}, "b3b70c8271a845709f9a03030e705da7")
+	attributesList, err := Mock{}.GetAttributes(context.Background(), &AttributeFilter{QueryName: "action"}, "b3b70c8271a845709f9a03030e705da7")
 
 	assert.Nil(t, err)
 	assert.Equal(t, len(attributesList), 6)

--- a/pkg/storage/opensearch.go
+++ b/pkg/storage/opensearch.go
@@ -382,12 +382,10 @@ func (os *OpenSearch) GetAttributes(ctx context.Context, filter *AttributeFilter
 	index := indexName()
 	logg.Debug("Looking for unique attributes for %s in index %s for tenant %s", filter.QueryName, index, tenantID)
 
-	// Map query name to OpenSearch field
-	var osName string
-	if val, ok := osFieldMapping[filter.QueryName]; ok {
-		osName = val
-	} else {
-		osName = filter.QueryName
+	// Map query name to OpenSearch field. Reject names outside the documented public set.
+	osName, ok := osFieldMapping[filter.QueryName]
+	if !ok {
+		return nil, fmt.Errorf("%w: %q", ErrUnknownAttributeName, filter.QueryName)
 	}
 	logg.Debug("Mapped Queryname: %s --> %s", filter.QueryName, osName)
 

--- a/pkg/storage/util.go
+++ b/pkg/storage/util.go
@@ -12,6 +12,8 @@ import (
 // CADFFieldMapping maps API field names to OpenSearch CADF index fields.
 // The .keyword suffix is used for exact-match queries and aggregations, avoiding text analysis and tokenization.
 // This mapping is shared across all storage backends to ensure consistency in CADF event querying.
+// The keys of this map define the documented public set of attribute names accepted by
+// GET /v1/attributes/{attribute_name}; names outside this set are rejected.
 var CADFFieldMapping = map[string]string{
 	"time":           "eventTime",
 	"action":         "action.keyword",
@@ -21,6 +23,7 @@ var CADFFieldMapping = map[string]string{
 	"observer_type":  "observer.typeURI.keyword",
 	"target_id":      "target.id.keyword",
 	"target_type":    "target.typeURI.keyword",
+	"resource_type":  "target.typeURI.keyword", // alias for target_type, per docs and ListEvents filter
 	"initiator_id":   "initiator.id.keyword",
 	"initiator_type": "initiator.typeURI.keyword",
 	"initiator_name": "initiator.name.keyword",


### PR DESCRIPTION
\`GET /v1/attributes/{attribute_name}\` previously forwarded unrecognized
names directly to OpenSearch as a \`terms.field\` value. This PR limits
accepted names to the documented public set (\`CADFFieldMapping\` keys),
returning HTTP 400 for anything outside it.

Also adds \`resource_type\` as an explicit entry in \`CADFFieldMapping\`
(alias for \`target_type\`), consistent with how \`ListEvents\` handles
that parameter.

**Verify:**
- \`GET /v1/attributes/action\` → 200 (existing behaviour)
- \`GET /v1/attributes/resource_type\` → 200 (existing behaviour)
- \`GET /v1/attributes/observer.id.keyword\` → 400 (new)
- \`make check\` passes