### PR TITLE
etc: update example config to use generic placeholder values

### DIFF
--- a/etc/hermes.conf
+++ b/etc/hermes.conf
@@ -26,10 +26,9 @@ url = "http://localhost:9200"
 #max_result_window = "20000"
 
 [keystone]
-auth_url = "https://identity-3.staging.cloud.sap/v3/"
-#auth_url = "https://keystone.example.com/v3"
+auth_url = "https://keystone.example.com/v3"
 username = "hermes"
-password = "C0nrad^"
+password = "your-keystone-password"
 user_domain_name = "Default"
 project_name = "service"
 project_domain_name = "Default"


### PR DESCRIPTION
Replace the `auth_url` and `password` values in `etc/hermes.conf`
with generic placeholders. The previous values referenced an old
environment that no longer exists.