### PR TITLE
feat(dataplane-config): add GET/PUT/DELETE endpoints for per-project routing config

### DIFF
--- a/docs/dataplane-config-read-contract.md
+++ b/docs/dataplane-config-read-contract.md
@@ -1,0 +1,131 @@
+<!--
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Dataplane Config — Log-Router Read Contract
+
+This document is the authoritative contract between hermez (writer) and log-router (reader)
+for the `dataplane_config` table. Log-router must implement against this spec; hermez
+must not break it without a migration and coordinated release.
+
+---
+
+## Database
+
+| Item | Value |
+|------|-------|
+| Host | PostgreSQL cluster provisioned by the `hermes` Helm chart |
+| Database | `hermes` (configurable via helm values) |
+| Table | `dataplane_config` |
+| Login role | `log_router` (provisioned by the Helm chart's postgres-ng seed) |
+| Granted role | `log_router_reader` NOLOGIN (created by hermez migration 001) |
+
+Log-router connects to postgres using the `log_router` login role, which is a member
+of `log_router_reader`. The `log_router_reader` role has `SELECT` on `dataplane_config`
+and nothing else — no INSERT, UPDATE, DELETE, or access to any other table.
+
+---
+
+## Table schema
+
+```sql
+CREATE TABLE dataplane_config (
+    project_id    VARCHAR(64) PRIMARY KEY,
+    enabled       BOOLEAN     NOT NULL DEFAULT FALSE,
+    target_bucket TEXT        NOT NULL DEFAULT '',
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by    VARCHAR(64) NOT NULL DEFAULT ''
+);
+```
+
+---
+
+## Reading a single project's config
+
+```sql
+SELECT project_id, enabled, target_bucket
+FROM dataplane_config
+WHERE project_id = $1;
+```
+
+Parameters: `$1` = Keystone project UUID (string).
+
+**If the query returns zero rows:** treat as disabled. The project has not opted in.
+Do NOT surface this as an error. Route only to the `ccadmin/master` bucket.
+
+**If the query returns a row with `enabled = false`:** same as missing — route only
+to the `ccadmin/master` bucket. Do not route to `target_bucket`.
+
+**If the query returns a row with `enabled = true`:** route to both `ccadmin/master`
+and `target_bucket`. The `target_bucket` value is validated by hermez at write time
+(RFC-1123 subset, 3–63 chars, lowercase + digits + hyphens). Trust it.
+
+---
+
+## Batch lookup (optional optimisation)
+
+If log-router processes events for many projects in one batch, a `WHERE project_id = ANY($1)`
+query is safe:
+
+```sql
+SELECT project_id, enabled, target_bucket
+FROM dataplane_config
+WHERE project_id = ANY($1)
+  AND enabled = TRUE;
+```
+
+Projects absent from the result → disabled.
+
+---
+
+## Caching
+
+Log-router SHOULD cache results with a TTL of 30 seconds (configurable). This prevents
+hammering postgres on every event.
+
+Cache invalidation is best-effort. Eventual consistency of up to 30 seconds is acceptable
+for a routing-toggle; operators and customers understand that toggling takes effect within
+a short window, not instantly.
+
+When the cache entry expires, re-query postgres. There is no push notification from hermez.
+
+---
+
+## Failure modes
+
+| Condition | Required behaviour |
+|-----------|-------------------|
+| Postgres unreachable | **Fail closed** — treat all projects as disabled. Route only to `ccadmin/master`. Log the error. Do NOT spray events into a bucket you cannot confirm is opted-in. |
+| Query returns unexpected error | Same as unreachable — fail closed. |
+| `target_bucket` empty on an `enabled=true` row | Should not happen (hermez validates at write time). Treat as disabled; log a warning with the project_id. |
+
+The ccadmin/master routing path is unconditional and must never consult this config.
+A hermez/postgres outage stops project-bucket routing only; the admin path is unaffected.
+
+---
+
+## Schema stability
+
+Hermez will not remove or rename existing columns without a coordination notice and a
+postgres migration. Log-router may safely rely on `project_id`, `enabled`, and
+`target_bucket` remaining stable.
+
+New columns may be added in future migrations. Log-router's `SELECT` list is explicit
+(not `SELECT *`) so additions are non-breaking.
+
+---
+
+## Credentials
+
+The `log_router` postgres login role is provisioned by the hermes Helm chart's
+`postgres-ng` seed values. Hermez does not manage this login role. The chart must:
+
+1. Create the `log_router` login role with a password.
+2. `GRANT log_router_reader TO log_router;`
+
+Hermez's migration creates the `log_router_reader` NOLOGIN role and grants it
+`SELECT ON dataplane_config`. If hermez starts before the chart seeds `log_router`,
+the GRANT will succeed on the next migration run because `GRANT ... TO log_router_reader`
+does not require `log_router` to exist.

--- a/etc/permissive-policy.json
+++ b/etc/permissive-policy.json
@@ -1,6 +1,7 @@
 {
-  "event:list":     "@",
-  "event:show":     "@",
-  "audit:show":    "@",
-  "audit:update":  "@"
+  "event:list":              "@",
+  "event:show":              "@",
+  "audit:show":              "@",
+  "audit:update":            "@",
+  "dataplane_config:manage": "@"
 }

--- a/etc/policy.json
+++ b/etc/policy.json
@@ -5,7 +5,9 @@
   "cluster_viewer": "project_domain_name:cloud_domain and project_name:cloud_admin_project",
   "domain_viewer":  "rule:domain_scope and role:audit_viewer",
   "project_viewer": "rule:project_scope and role:audit_viewer",
-  
-  "event:list":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
-  "event:show":     "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer"
+  "project_admin":  "rule:project_scope and role:audit_admin",
+
+  "event:list":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
+  "event:show":               "rule:project_viewer or rule:domain_viewer or rule:cluster_viewer",
+  "dataplane_config:manage":  "rule:project_admin"
 }

--- a/go.mod
+++ b/go.mod
@@ -24,13 +24,16 @@ require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gofrs/uuid/v5 v5.4.0 // indirect
+	github.com/golang-migrate/migrate/v4 v4.19.1 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/lib/pq v1.12.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
+	github.com/rabbitmq/amqp091-go v1.12.0 // indirect
 	github.com/sagikazarmark/locafero v0.7.0 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.12.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/gofrs/uuid/v5 v5.4.0 h1:EfbpCTjqMuGyq5ZJwxqzn3Cbr2d0rUZU7v5ycAk/e/0=
 github.com/gofrs/uuid/v5 v5.4.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
+github.com/golang-migrate/migrate/v4 v4.19.1 h1:OCyb44lFuQfYXYLx1SCxPZQGU7mcaZ7gH9yH4jSFbBA=
+github.com/golang-migrate/migrate/v4 v4.19.1/go.mod h1:CTcgfjxhaUtsLipnLoQRWCrjYXycRz/g5+RWDuYgPrE=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -38,6 +40,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
+github.com/lib/pq v1.12.3 h1:tTWxr2YLKwIvK90ZXEw8GP7UFHtcbTtty8zsI+YjrfQ=
+github.com/lib/pq v1.12.3/go.mod h1:/p+8NSbOcwzAEI7wiMXFlgydTwcgTr3OSKMsD2BitpA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/opensearch-project/opensearch-go/v4 v4.5.0 h1:26XckmmF6MhlXt91Bu1yY6R51jy1Ns/C3XgIfvyeTRo=
@@ -54,6 +58,8 @@ github.com/prometheus/common v0.69.0 h1:OA85nJQS/T/MaYh/Q2CcgDKSGWqNIgrBDvDH85Cu
 github.com/prometheus/common v0.69.0/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
 github.com/prometheus/procfs v0.17.0 h1:FuLQ+05u4ZI+SS/w9+BWEM2TXiHKsUQ9TADiRH7DuK0=
 github.com/prometheus/procfs v0.17.0/go.mod h1:oPQLaDAMRbA+u8H5Pbfq+dl3VDAvHxMUOVhe0wYB2zw=
+github.com/rabbitmq/amqp091-go v1.12.0 h1:V0v14Iqfs+MwHWihJt/nGS5Ulu0vw572b2Co3mwunkI=
+github.com/rabbitmq/amqp091-go v1.12.0/go.mod h1:Hy4jKW5kQART1u+JkDTF9YYOQUHXqMuhrgxOEeS7G4o=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=

--- a/main.go
+++ b/main.go
@@ -11,7 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/httpext"
 	"github.com/sapcc/go-bits/logg"
 	"github.com/sapcc/go-bits/mock"
 	"github.com/sapcc/go-bits/must"
@@ -20,6 +22,7 @@ import (
 
 	"github.com/sapcc/hermes/pkg/api"
 	"github.com/sapcc/hermes/pkg/identity"
+	"github.com/sapcc/hermes/pkg/routing"
 	"github.com/sapcc/hermes/pkg/storage"
 )
 
@@ -47,8 +50,14 @@ func main() {
 
 	keystoneDriver := configuredKeystoneDriver()
 	storageDriver := configuredStorageDriver()
+	routingStore := configuredRoutingStore()
 
-	must.Succeed(api.Server(keystoneDriver, storageDriver))
+	// Create the context here so the auditor's delivery goroutine participates
+	// in graceful shutdown alongside the HTTP server.
+	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)
+	auditor := configuredAuditor(ctx)
+
+	must.Succeed(api.Server(ctx, keystoneDriver, storageDriver, routingStore, auditor))
 }
 
 func parseCmdlineFlags() {
@@ -65,9 +74,14 @@ func parseCmdlineFlags() {
 func setDefaultConfig() {
 	viper.SetDefault("hermes.keystone_driver", "keystone")
 	viper.SetDefault("hermes.storage_driver", "opensearch")
+	viper.SetDefault("hermes.routing_store_driver", "postgres")
 	viper.SetDefault("API.ListenAddress", "0.0.0.0:8788")
 	viper.SetDefault("opensearch.url", "http://localhost:9200")
 	viper.SetDefault("opensearch.max_result_window", "20000")
+	viper.SetDefault("postgres.hostname", "localhost")
+	viper.SetDefault("postgres.port", "5432")
+	viper.SetDefault("postgres.username", "hermes")
+	viper.SetDefault("postgres.dbname", "hermes")
 }
 
 func readConfig(configPath *string) {
@@ -128,4 +142,44 @@ func configuredStorageDriver() storage.Storage {
 		logg.Fatal("unknown storage_driver %q", driverName)
 		return nil // unreachable
 	}
+}
+
+func configuredRoutingStore() routing.Store {
+	driverName := viper.GetString("hermes.routing_store_driver")
+	switch driverName {
+	case "postgres":
+		return must.Return(routing.NewPostgres())
+	case "mock":
+		return routing.NewMock()
+	default:
+		logg.Fatal("unknown routing_store_driver %q", driverName)
+		return nil // unreachable
+	}
+}
+
+// configuredAuditor builds the audit event publisher.
+// When HERMES_AUDIT_RABBITMQ_QUEUE_NAME is set, events are delivered to RabbitMQ.
+// Otherwise a null auditor is used — events are logged at DEBUG level and discarded.
+// This allows running Hermes without a RabbitMQ connection in development/test environments.
+//
+// Required env vars (when queue name is set):
+//
+//	HERMES_AUDIT_RABBITMQ_QUEUE_NAME  — queue to publish to (production: "notifications.info")
+//	HERMES_AUDIT_RABBITMQ_HOSTNAME    — broker host (production: "hermes-rabbitmq-notifications.hermes.svc")
+//	HERMES_AUDIT_RABBITMQ_PORT        — broker port (default: 5672)
+//	HERMES_AUDIT_RABBITMQ_USERNAME    — AMQP username (from vault: hermes/rabbitmq-user/notifications-default/user)
+//	HERMES_AUDIT_RABBITMQ_PASSWORD    — AMQP password (from vault: hermes/rabbitmq-user/notifications-default/password)
+func configuredAuditor(ctx context.Context) audittools.Auditor {
+	if osext.GetenvOrDefault("HERMES_AUDIT_RABBITMQ_QUEUE_NAME", "") == "" {
+		logg.Error("HERMES_AUDIT_RABBITMQ_QUEUE_NAME is not set — audit events will be discarded (null auditor)")
+		return audittools.NewNullAuditor()
+	}
+	return must.Return(audittools.NewAuditor(ctx, audittools.AuditorOpts{
+		EnvPrefix: "HERMES_AUDIT_RABBITMQ_",
+		Observer: audittools.Observer{
+			TypeURI: "service/hermes",
+			Name:    "hermes",
+			ID:      audittools.GenerateUUID(),
+		},
+	}))
 }

--- a/main.go
+++ b/main.go
@@ -78,10 +78,6 @@ func setDefaultConfig() {
 	viper.SetDefault("API.ListenAddress", "0.0.0.0:8788")
 	viper.SetDefault("opensearch.url", "http://localhost:9200")
 	viper.SetDefault("opensearch.max_result_window", "20000")
-	viper.SetDefault("postgres.hostname", "localhost")
-	viper.SetDefault("postgres.port", "5432")
-	viper.SetDefault("postgres.username", "hermes")
-	viper.SetDefault("postgres.dbname", "hermes")
 }
 
 func readConfig(configPath *string) {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -14,9 +14,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/viper"
 
+	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/mock"
 
+	"github.com/sapcc/hermes/pkg/routing"
 	"github.com/sapcc/hermes/pkg/storage"
 	"github.com/sapcc/hermes/pkg/test"
 )
@@ -41,11 +43,12 @@ func setupTest(t *testing.T) http.Handler {
 	// create test driver with the domains and projects from start-data.sql
 	validator := mock.NewValidator(mock.NewEnforcer(), nil)
 	storageInterface := storage.Mock{}
+	routingStore := routing.NewMock()
 
 	prometheus.DefaultRegisterer = prometheus.NewPedanticRegistry()
 
 	// Create API compositions using httpapi
-	v1API := NewV1API(validator, storageInterface)
+	v1API := NewV1API(validator, storageInterface, routingStore, audittools.NewNullAuditor())
 	versionAPI := NewVersionAPI(v1API.VersionData())
 	metricsAPI := NewMetricsAPI()
 

--- a/pkg/api/core.go
+++ b/pkg/api/core.go
@@ -9,9 +9,11 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
 
+	"github.com/sapcc/hermes/pkg/routing"
 	"github.com/sapcc/hermes/pkg/storage"
 )
 
@@ -32,8 +34,10 @@ type versionLinkData struct {
 
 // v1Provider provides backward compatibility for existing handler methods
 type v1Provider struct {
-	validator gopherpolicy.Validator
-	storage   storage.Storage
+	validator    gopherpolicy.Validator
+	storage      storage.Storage
+	routingStore routing.Store
+	auditor      audittools.Auditor
 }
 
 // AuthHandler wraps endpoint handlers with consistent auth logic.
@@ -63,10 +67,12 @@ func (p *v1Provider) AuthHandler(w http.ResponseWriter, r *http.Request, rule st
 
 // V1API implements the v1 API endpoints using httpapi patterns
 type V1API struct {
-	validator   gopherpolicy.Validator
-	storage     storage.Storage
-	versionData VersionData
-	provider    *v1Provider
+	validator    gopherpolicy.Validator
+	storage      storage.Storage
+	routingStore routing.Store
+	auditor      audittools.Auditor
+	versionData  VersionData
+	provider     *v1Provider
 }
 
 // NewV1API creates a new V1API instance with the provided validator and storage.
@@ -75,14 +81,18 @@ type V1API struct {
 //
 //	validator := gopherpolicy.NewValidator(enforcer, logger)
 //	storage := opensearch.NewStorage(config)
-//	api := NewV1API(validator, storage)
-func NewV1API(validator gopherpolicy.Validator, storageInterface storage.Storage) *V1API {
+//	api := NewV1API(validator, storage, routingStore, auditor)
+func NewV1API(validator gopherpolicy.Validator, storageInterface storage.Storage, routingStore routing.Store, auditor audittools.Auditor) *V1API {
 	api := &V1API{
-		validator: validator,
-		storage:   storageInterface,
+		validator:    validator,
+		storage:      storageInterface,
+		routingStore: routingStore,
+		auditor:      auditor,
 		provider: &v1Provider{
-			validator: validator,
-			storage:   storageInterface,
+			validator:    validator,
+			storage:      storageInterface,
+			routingStore: routingStore,
+			auditor:      auditor,
 		},
 	}
 
@@ -123,6 +133,15 @@ func (api *V1API) AddTo(r *mux.Router) {
 
 	r.Methods("GET").Path("/v1/attributes/{attribute_name}").Handler(
 		InstrumentDuration("GetAttributes")(InstrumentResponseSize("GetAttributes")(http.HandlerFunc(api.getAttributes))))
+
+	r.Methods("GET").Path("/v1/projects/{project_id}/dataplane-config").Handler(
+		InstrumentDuration("GetDataplaneConfig")(InstrumentResponseSize("GetDataplaneConfig")(http.HandlerFunc(api.getDataplaneConfig))))
+
+	r.Methods("PUT").Path("/v1/projects/{project_id}/dataplane-config").Handler(
+		InstrumentDuration("PutDataplaneConfig")(InstrumentResponseSize("PutDataplaneConfig")(http.HandlerFunc(api.putDataplaneConfig))))
+
+	r.Methods("DELETE").Path("/v1/projects/{project_id}/dataplane-config").Handler(
+		InstrumentDuration("DeleteDataplaneConfig")(InstrumentResponseSize("DeleteDataplaneConfig")(http.HandlerFunc(api.deleteDataplaneConfig))))
 }
 
 // Handler methods for V1API
@@ -160,4 +179,22 @@ func (api *V1API) getAttributes(w http.ResponseWriter, r *http.Request) {
 
 	// Call existing v1Provider implementation for backward compatibility
 	api.provider.GetAttributes(w, r)
+}
+
+// getDataplaneConfig handles GET /v1/projects/{project_id}/dataplane-config
+func (api *V1API) getDataplaneConfig(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/projects/:project_id/dataplane-config")
+	api.provider.GetDataplaneConfig(w, r)
+}
+
+// putDataplaneConfig handles PUT /v1/projects/{project_id}/dataplane-config
+func (api *V1API) putDataplaneConfig(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/projects/:project_id/dataplane-config")
+	api.provider.PutDataplaneConfig(w, r)
+}
+
+// deleteDataplaneConfig handles DELETE /v1/projects/{project_id}/dataplane-config
+func (api *V1API) deleteDataplaneConfig(w http.ResponseWriter, r *http.Request) {
+	httpapi.IdentifyEndpoint(r, "/v1/projects/:project_id/dataplane-config")
+	api.provider.DeleteDataplaneConfig(w, r)
 }

--- a/pkg/api/dataplane_config.go
+++ b/pkg/api/dataplane_config.go
@@ -1,0 +1,234 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-bits/audittools"
+	"github.com/sapcc/go-bits/gopherpolicy"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/respondwith"
+
+	"github.com/sapcc/hermes/pkg/routing"
+)
+
+// s3BucketNamePattern enforces RFC-1123-subset S3 bucket name rules:
+// lowercase letters, digits, and hyphens; must start/end with letter or digit;
+// 3–63 characters. Consecutive hyphens (e.g. "my--bucket") are rejected
+// separately because they are prohibited by both AWS S3 and Ceph RGW.
+var s3BucketNamePattern = regexp.MustCompile(`^[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]$`)
+
+// dataplaneConfigRequest is the shape accepted on PUT.
+// We use strict decoding (DisallowUnknownFields) so unknown fields → 400.
+type dataplaneConfigRequest struct {
+	Enabled      bool   `json:"enabled"`
+	TargetBucket string `json:"target_bucket"`
+}
+
+// GetDataplaneConfig handles GET /v1/projects/{project_id}/dataplane-config.
+// Returns 200 with the default (disabled) payload when no config exists.
+func (p *v1Provider) GetDataplaneConfig(res http.ResponseWriter, req *http.Request) {
+	projectID := mux.Vars(req)["project_id"]
+	if _, ok := p.authDataplaneConfig(res, req, projectID); !ok {
+		return
+	}
+
+	cfg, err := p.routingStore.Get(req.Context(), projectID)
+	if errors.Is(err, routing.ErrNotFound) {
+		cfg = nil // treat as default
+	} else if err != nil {
+		logg.Error("dataplane-config GET: storage error for project %s: %s", projectID, err)
+		respondwith.ObfuscatedErrorText(res, err)
+		return
+	}
+
+	if cfg == nil {
+		def := routing.DefaultDataplaneConfig(projectID)
+		ReturnESJSON(res, http.StatusOK, def)
+		return
+	}
+	ReturnESJSON(res, http.StatusOK, cfg)
+}
+
+// PutDataplaneConfig handles PUT /v1/projects/{project_id}/dataplane-config.
+// Idempotent create-or-replace. Returns 200 with the saved document.
+// An audit event is emitted for every attempt — successful or not.
+func (p *v1Provider) PutDataplaneConfig(res http.ResponseWriter, req *http.Request) {
+	projectID := mux.Vars(req)["project_id"]
+	token, ok := p.authDataplaneConfig(res, req, projectID)
+	if !ok {
+		return
+	}
+
+	now := time.Now().UTC()
+	userID := token.Context.Auth["user_id"]
+	if userID == "" {
+		http.Error(res, "token missing user identity", http.StatusUnauthorized)
+		return
+	}
+
+	// recordAttempt emits a CADF event regardless of outcome.
+	// cfg is nil when we can't construct the target (parse error before cfg is built).
+	recordAttempt := func(reasonCode int, cfg *routing.DataplaneConfig) {
+		target := routing.DataplaneConfig{ProjectID: projectID, UpdatedBy: userID}
+		if cfg != nil {
+			target = *cfg
+		}
+		p.auditor.Record(audittools.Event{
+			Time:       now,
+			Request:    req,
+			User:       token,
+			ReasonCode: reasonCode,
+			Action:     cadf.UpdateAction,
+			Target:     target,
+		})
+	}
+
+	// Content-Type enforcement
+	if ct := req.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		http.Error(res, "Content-Type must be application/json", http.StatusUnsupportedMediaType)
+		recordAttempt(http.StatusUnsupportedMediaType, nil)
+		return
+	}
+
+	// Body size cap: 64 KiB
+	req.Body = http.MaxBytesReader(res, req.Body, 64*1024)
+
+	decoder := json.NewDecoder(req.Body)
+	decoder.DisallowUnknownFields()
+	var body dataplaneConfigRequest
+	if err := decoder.Decode(&body); err != nil {
+		http.Error(res, "invalid request body: "+err.Error(), http.StatusBadRequest)
+		recordAttempt(http.StatusBadRequest, nil)
+		return
+	}
+
+	// Validate target_bucket whenever it is non-empty — regardless of enabled flag.
+	// This prevents storing an invalid bucket name that would silently break routing
+	// if the config is later re-enabled without updating the bucket.
+	if body.TargetBucket != "" {
+		if !s3BucketNamePattern.MatchString(body.TargetBucket) {
+			http.Error(res, "target_bucket must be 3–63 chars, lowercase letters/digits/hyphens only, start and end with letter or digit", http.StatusBadRequest)
+			recordAttempt(http.StatusBadRequest, nil)
+			return
+		}
+		if strings.Contains(body.TargetBucket, "--") {
+			http.Error(res, "target_bucket must not contain consecutive hyphens", http.StatusBadRequest)
+			recordAttempt(http.StatusBadRequest, nil)
+			return
+		}
+	}
+
+	// When enabled, a non-empty bucket is required.
+	if body.Enabled && body.TargetBucket == "" {
+		http.Error(res, "target_bucket is required when enabled is true", http.StatusBadRequest)
+		recordAttempt(http.StatusBadRequest, nil)
+		return
+	}
+
+	cfg := routing.DataplaneConfig{
+		ProjectID:    projectID,
+		Enabled:      body.Enabled,
+		TargetBucket: body.TargetBucket,
+		UpdatedAt:    now,
+		UpdatedBy:    userID,
+	}
+
+	if err := p.routingStore.Upsert(req.Context(), cfg); err != nil {
+		logg.Error("dataplane-config PUT: storage error for project %s: %s", projectID, err)
+		respondwith.ObfuscatedErrorText(res, err)
+		recordAttempt(http.StatusInternalServerError, &cfg)
+		return
+	}
+
+	logg.Info("dataplane-config PUT: project=%s enabled=%v updated_by=%s", projectID, cfg.Enabled, userID)
+	recordAttempt(http.StatusOK, &cfg)
+	ReturnESJSON(res, http.StatusOK, cfg)
+}
+
+// DeleteDataplaneConfig handles DELETE /v1/projects/{project_id}/dataplane-config.
+// Idempotent — deleting a non-existent config returns 204.
+// An audit event is emitted only when a config actually existed and was removed;
+// no-op deletes are silent (no spurious events for resources that never existed).
+func (p *v1Provider) DeleteDataplaneConfig(res http.ResponseWriter, req *http.Request) {
+	projectID := mux.Vars(req)["project_id"]
+	token, ok := p.authDataplaneConfig(res, req, projectID)
+	if !ok {
+		return
+	}
+
+	now := time.Now().UTC()
+	userID := token.Context.Auth["user_id"]
+	if userID == "" {
+		http.Error(res, "token missing user identity", http.StatusUnauthorized)
+		return
+	}
+
+	deleted, err := p.routingStore.Delete(req.Context(), projectID)
+	if err != nil {
+		logg.Error("dataplane-config DELETE: storage error for project %s: %s", projectID, err)
+		respondwith.ObfuscatedErrorText(res, err)
+		// Emit failure event — the attempt was made even though storage failed.
+		p.auditor.Record(audittools.Event{
+			Time:       now,
+			Request:    req,
+			User:       token,
+			ReasonCode: http.StatusInternalServerError,
+			Action:     cadf.DeleteAction,
+			Target:     routing.DataplaneConfig{ProjectID: projectID, UpdatedBy: userID},
+		})
+		return
+	}
+
+	// Only emit an audit event when something was actually removed.
+	// A DELETE on a non-existent config is a safe no-op — recording it would
+	// pollute the audit trail with spurious events for resources that never existed.
+	if deleted {
+		p.auditor.Record(audittools.Event{
+			Time:       now,
+			Request:    req,
+			User:       token,
+			ReasonCode: http.StatusNoContent,
+			Action:     cadf.DeleteAction,
+			Target:     routing.DataplaneConfig{ProjectID: projectID, UpdatedBy: userID},
+		})
+	}
+
+	logg.Info("dataplane-config DELETE: project=%s updated_by=%s deleted=%v", projectID, userID, deleted)
+	res.WriteHeader(http.StatusNoContent)
+}
+
+// authDataplaneConfig validates the Keystone token against the
+// "dataplane_config:manage" policy rule and enforces that the path
+// project_id matches the token's project scope.
+//
+// Returns the token and true on success; writes the error response and
+// returns false on failure.
+func (p *v1Provider) authDataplaneConfig(res http.ResponseWriter, req *http.Request, pathProjectID string) (*gopherpolicy.Token, bool) {
+	token := p.validator.CheckToken(req)
+	token.Context.Request = mux.Vars(req)
+	token.Context.Request["domain_id"] = token.Context.Auth["domain_id"]
+	token.Context.Request["project_id"] = token.Context.Auth["project_id"]
+
+	if !token.Require(res, "dataplane_config:manage") {
+		return nil, false
+	}
+
+	// Cross-project access check: path project_id must match the token scope.
+	tokenProjectID := token.Context.Auth["project_id"]
+	if tokenProjectID != pathProjectID {
+		http.Error(res, "project_id in path does not match token scope", http.StatusForbidden)
+		return nil, false
+	}
+
+	return token, true
+}

--- a/pkg/api/dataplane_config_test.go
+++ b/pkg/api/dataplane_config_test.go
@@ -1,0 +1,380 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	policy "github.com/databus23/goslo.policy"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/spf13/viper"
+
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-bits/audittools"
+	"github.com/sapcc/go-bits/httpapi"
+	"github.com/sapcc/go-bits/mock"
+	"github.com/sapcc/go-bits/must"
+
+	"github.com/sapcc/hermes/pkg/routing"
+	"github.com/sapcc/hermes/pkg/storage"
+	"github.com/sapcc/hermes/pkg/test"
+)
+
+const testProjectID = "test-project-1"
+const dataplaneConfigPath = "/v1/projects/" + testProjectID + "/dataplane-config"
+
+// updateEvent and deleteEvent build cadf.Event values that match what MockAuditor records after normalization.
+// MockAuditor.normalize zeroes out ID, EventTime, TypeURI, EventType, Observer, and the standard Initiator.
+// What remains and must match: Action, Outcome, Reason, RequestPath, Target (including Attachments).
+func updateEvent(reasonCode int, target cadf.Resource) cadf.Event {
+	outcome := cadf.FailureOutcome
+	if reasonCode >= 200 && reasonCode < 300 {
+		outcome = cadf.SuccessOutcome
+	}
+	return cadf.Event{
+		Action:  cadf.UpdateAction,
+		Outcome: outcome,
+		Reason: cadf.Reason{
+			ReasonType: "HTTP",
+			ReasonCode: strconv.Itoa(reasonCode),
+		},
+		RequestPath: dataplaneConfigPath,
+		Target:      target,
+	}
+}
+
+func deleteEvent(reasonCode int, target cadf.Resource) cadf.Event {
+	outcome := cadf.FailureOutcome
+	if reasonCode >= 200 && reasonCode < 300 {
+		outcome = cadf.SuccessOutcome
+	}
+	return cadf.Event{
+		Action:  cadf.DeleteAction,
+		Outcome: outcome,
+		Reason: cadf.Reason{
+			ReasonType: "HTTP",
+			ReasonCode: strconv.Itoa(reasonCode),
+		},
+		RequestPath: dataplaneConfigPath,
+		Target:      target,
+	}
+}
+
+// dataplaneTarget builds the cadf.Resource for DataplaneConfig.Render() for testProjectID.
+func dataplaneTarget(attachments []cadf.Attachment) cadf.Resource {
+	return cadf.Resource{
+		TypeURI:     "service/hermes/dataplane-config",
+		ID:          testProjectID,
+		ProjectID:   testProjectID,
+		Attachments: attachments,
+	}
+}
+
+// payloadAttachment builds the JSON attachment that DataplaneConfig.Render() adds.
+func payloadAttachment(enabled bool, targetBucket string) []cadf.Attachment {
+	return []cadf.Attachment{
+		must.Return(cadf.NewJSONAttachment("payload", map[string]any{
+			"enabled":       enabled,
+			"target_bucket": targetBucket,
+		})),
+	}
+}
+
+// setupDataplaneTest creates a handler where the mock token is scoped to testProjectID.
+// This is needed because authDataplaneConfig enforces path-vs-token project match.
+// Returns the handler, the routing mock store, and the mock auditor for event assertions.
+func setupDataplaneTest(t *testing.T) (http.Handler, *routing.Mock, *audittools.MockAuditor) {
+	t.Helper()
+
+	policyBytes, err := os.ReadFile("../test/policy.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	policyRules := make(map[string]string)
+	if err := json.Unmarshal(policyBytes, &policyRules); err != nil {
+		t.Fatal(err)
+	}
+	policyEnforcer, err := policy.NewEnforcer(policyRules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	viper.Set("hermes.PolicyEnforcer", policyEnforcer)
+
+	validator := mock.NewValidator(mock.NewEnforcer(), map[string]string{
+		"project_id": testProjectID,
+		"user_id":    "user-abc",
+	})
+	routingStore := routing.NewMock()
+	mockAuditor := audittools.NewMockAuditor()
+
+	prometheus.DefaultRegisterer = prometheus.NewPedanticRegistry()
+
+	v1API := NewV1API(validator, storage.Mock{}, routingStore, mockAuditor)
+	return httpapi.Compose(v1API, NewVersionAPI(v1API.VersionData()), NewMetricsAPI()), routingStore, mockAuditor
+}
+
+// putJSON issues a PUT to dataplaneConfigPath with a JSON body and returns the recorder.
+func putJSON(t *testing.T, handler http.Handler, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	b, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut, dataplaneConfigPath, bytes.NewReader(b))
+	req.Header.Set("X-Auth-Token", "something")
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
+// TestDataplaneConfig_GetDefault proves GET returns the disabled default when no config exists.
+func TestDataplaneConfig_GetDefault(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	test.APIRequest{
+		Method:           "GET",
+		Path:             "/v1/projects/" + testProjectID + "/dataplane-config",
+		ExpectStatusCode: http.StatusOK,
+		ExpectJSON:       "fixtures/dataplane-config-default.json",
+	}.Check(t, handler)
+	// GET does not emit audit events.
+	auditor.ExpectEvents(t /* none */)
+}
+
+// TestDataplaneConfig_PutAndGet proves PUT persists and a subsequent GET returns the saved config.
+// Also asserts the audit event is emitted with UpdateAction and success outcome.
+func TestDataplaneConfig_PutAndGet(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	path := "/v1/projects/" + testProjectID + "/dataplane-config"
+
+	// PUT valid config
+	rec := putJSON(t, handler, map[string]any{
+		"enabled":       true,
+		"target_bucket": "my-audit-bucket",
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("PUT expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	// Verify the response contains the expected fields.
+	var resp routing.DataplaneConfig
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("PUT response is not valid JSON: %s", err)
+	}
+	if resp.ProjectID != testProjectID {
+		t.Errorf("PUT response project_id: want %q, got %q", testProjectID, resp.ProjectID)
+	}
+	if !resp.Enabled {
+		t.Error("PUT response enabled: want true, got false")
+	}
+	if resp.TargetBucket != "my-audit-bucket" {
+		t.Errorf("PUT response target_bucket: want %q, got %q", "my-audit-bucket", resp.TargetBucket)
+	}
+	if resp.UpdatedBy != "user-abc" {
+		t.Errorf("PUT response updated_by: want %q, got %q", "user-abc", resp.UpdatedBy)
+	}
+	if resp.UpdatedAt.IsZero() {
+		t.Error("PUT response updated_at must be set")
+	}
+
+	// Assert one audit event was emitted with UpdateAction and success.
+	auditor.ExpectEvents(t, updateEvent(
+		http.StatusOK,
+		dataplaneTarget(payloadAttachment(true, "my-audit-bucket")),
+	))
+
+	// GET after PUT must return the same config.
+	getReq := httptest.NewRequest(http.MethodGet, path, http.NoBody)
+	getReq.Header.Set("X-Auth-Token", "something")
+	getRec := httptest.NewRecorder()
+	handler.ServeHTTP(getRec, getReq)
+	if getRec.Code != http.StatusOK {
+		t.Fatalf("GET after PUT expected 200, got %d: %s", getRec.Code, getRec.Body.String())
+	}
+	var getResp routing.DataplaneConfig
+	if err := json.Unmarshal(getRec.Body.Bytes(), &getResp); err != nil {
+		t.Fatalf("GET response is not valid JSON: %s", err)
+	}
+	if getResp.ProjectID != testProjectID || !getResp.Enabled || getResp.TargetBucket != "my-audit-bucket" {
+		t.Errorf("GET after PUT mismatch: %+v", getResp)
+	}
+}
+
+// TestDataplaneConfig_PutEnabledMissingBucket proves PUT with enabled=true and no target_bucket → 400.
+// A failure audit event must still be emitted.
+func TestDataplaneConfig_PutEnabledMissingBucket(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	rec := putJSON(t, handler, map[string]any{
+		"enabled": true,
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	auditor.ExpectEvents(t, updateEvent(
+		http.StatusBadRequest,
+		dataplaneTarget(payloadAttachment(false, "")),
+	))
+}
+
+// TestDataplaneConfig_PutInvalidBucketName proves PUT with a bucket name that fails RFC-1123 → 400.
+func TestDataplaneConfig_PutInvalidBucketName(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	cases := []string{
+		"UPPERCASE",
+		"has space",
+		"ab",         // too short (< 3 chars)
+		"-start",     // starts with hyphen
+		"my--bucket", // consecutive hyphens (prohibited by S3 and Ceph RGW)
+	}
+	for _, bucket := range cases {
+		rec := putJSON(t, handler, map[string]any{
+			"enabled":       true,
+			"target_bucket": bucket,
+		})
+		if rec.Code != http.StatusBadRequest {
+			t.Errorf("bucket %q: expected 400, got %d", bucket, rec.Code)
+		}
+	}
+	// One failure event per invalid bucket attempt.
+	nilCfgTarget := dataplaneTarget(payloadAttachment(false, ""))
+	expected := make([]cadf.Event, len(cases))
+	for i := range expected {
+		expected[i] = updateEvent(http.StatusBadRequest, nilCfgTarget)
+	}
+	auditor.ExpectEvents(t, expected...)
+}
+
+// TestDataplaneConfig_PutUnknownField proves PUT rejects unknown JSON fields with 400.
+func TestDataplaneConfig_PutUnknownField(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	rec := putJSON(t, handler, map[string]any{
+		"enabled":       false,
+		"target_bucket": "",
+		"extra_field":   "should-fail",
+	})
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", rec.Code, rec.Body.String())
+	}
+	auditor.ExpectEvents(t, updateEvent(
+		http.StatusBadRequest,
+		dataplaneTarget(payloadAttachment(false, "")),
+	))
+}
+
+// TestDataplaneConfig_DeleteAndGet proves DELETE removes config; subsequent GET returns the default.
+// Also asserts a delete audit event is emitted.
+func TestDataplaneConfig_DeleteAndGet(t *testing.T) {
+	handler, routingStore, auditor := setupDataplaneTest(t)
+	path := "/v1/projects/" + testProjectID + "/dataplane-config"
+
+	// Seed a config to delete
+	if err := routingStore.Upsert(t.Context(), routing.DataplaneConfig{
+		ProjectID:    testProjectID,
+		Enabled:      true,
+		TargetBucket: "my-audit-bucket",
+		UpdatedAt:    time.Now().UTC(),
+		UpdatedBy:    "user-abc",
+	}); err != nil {
+		t.Fatalf("failed to seed routing config: %s", err)
+	}
+
+	// DELETE
+	delReq := httptest.NewRequest(http.MethodDelete, path, http.NoBody)
+	delReq.Header.Set("X-Auth-Token", "something")
+	delRec := httptest.NewRecorder()
+	handler.ServeHTTP(delRec, delReq)
+	if delRec.Code != http.StatusNoContent {
+		t.Fatalf("DELETE expected 204, got %d: %s", delRec.Code, delRec.Body.String())
+	}
+
+	// Assert delete audit event.
+	auditor.ExpectEvents(t, deleteEvent(
+		http.StatusNoContent,
+		dataplaneTarget(payloadAttachment(false, "")),
+	))
+
+	// GET after DELETE must return the default (disabled) config.
+	test.APIRequest{
+		Method:           "GET",
+		Path:             path,
+		ExpectStatusCode: http.StatusOK,
+		ExpectJSON:       "fixtures/dataplane-config-default.json",
+	}.Check(t, handler)
+}
+
+// TestDataplaneConfig_DeleteNonExistent proves DELETE on non-existent config is idempotent (204)
+// and does NOT emit an audit event (no resource existed to delete).
+func TestDataplaneConfig_DeleteNonExistent(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/projects/"+testProjectID+"/dataplane-config", http.NoBody)
+	req.Header.Set("X-Auth-Token", "something")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d: %s", rec.Code, rec.Body.String())
+	}
+	// No event — the resource never existed.
+	auditor.ExpectEvents(t /* none */)
+}
+
+// TestDataplaneConfig_CrossProjectForbidden proves that a token scoped to
+// testProjectID cannot access a different project's config (403).
+func TestDataplaneConfig_CrossProjectForbidden(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t) // token project_id = testProjectID
+
+	differentProject := "other-project-99"
+	otherPath := "/v1/projects/" + differentProject + "/dataplane-config"
+
+	// GET and DELETE use NoBody.
+	for _, method := range []string{"GET", "DELETE"} {
+		req := httptest.NewRequest(method, otherPath, http.NoBody)
+		req.Header.Set("X-Auth-Token", "something")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		if rec.Code != http.StatusForbidden {
+			t.Errorf("%s to different project: expected 403, got %d", method, rec.Code)
+		}
+	}
+
+	// PUT to a different project also requires a body (Content-Type enforcement happens
+	// after the project-ID check, but providing valid JSON is cleaner than relying on ordering).
+	putBody, err := json.Marshal(map[string]any{"enabled": false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	putReq := httptest.NewRequest(http.MethodPut, otherPath, bytes.NewReader(putBody))
+	putReq.Header.Set("X-Auth-Token", "something")
+	putReq.Header.Set("Content-Type", "application/json")
+	putRec := httptest.NewRecorder()
+	handler.ServeHTTP(putRec, putReq)
+	if putRec.Code != http.StatusForbidden {
+		t.Errorf("PUT to different project: expected 403, got %d", putRec.Code)
+	}
+
+	// 403 happens before the handler body runs — no audit events from our code.
+	auditor.ExpectEvents(t /* none */)
+}
+
+// TestDataplaneConfig_DisabledPutAcceptsEmptyBucket proves PUT with enabled=false
+// does not require target_bucket (routing is off, bucket is irrelevant).
+func TestDataplaneConfig_DisabledPutAcceptsEmptyBucket(t *testing.T) {
+	handler, _, auditor := setupDataplaneTest(t)
+	rec := putJSON(t, handler, map[string]any{
+		"enabled": false,
+	})
+	if rec.Code != http.StatusOK {
+		t.Errorf("PUT disabled without bucket: expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	auditor.ExpectEvents(t, updateEvent(
+		http.StatusOK,
+		dataplaneTarget(payloadAttachment(false, "")),
+	))
+}

--- a/pkg/api/fixtures/dataplane-config-default.json
+++ b/pkg/api/fixtures/dataplane-config-default.json
@@ -1,0 +1,6 @@
+{
+  "project_id": "test-project-1",
+  "enabled": false,
+  "updated_at": "0001-01-01T00:00:00Z",
+  "updated_by": ""
+}

--- a/pkg/api/fixtures/dataplane-config-default.json.license
+++ b/pkg/api/fixtures/dataplane-config-default.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+
+SPDX-License-Identifier: Apache-2.0

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -5,25 +5,26 @@ package api
 
 import (
 	"context"
-	"time"
 
 	"github.com/rs/cors"
 	"github.com/spf13/viper"
 
+	"github.com/sapcc/go-bits/audittools"
 	"github.com/sapcc/go-bits/gopherpolicy"
 	"github.com/sapcc/go-bits/httpapi"
 	"github.com/sapcc/go-bits/httpext"
 	"github.com/sapcc/go-bits/logg"
 
+	"github.com/sapcc/hermes/pkg/routing"
 	"github.com/sapcc/hermes/pkg/storage"
 )
 
 // Server Set up and start the API server using httpapi patterns
-func Server(validator gopherpolicy.Validator, storageInterface storage.Storage) error {
+func Server(ctx context.Context, validator gopherpolicy.Validator, storageInterface storage.Storage, routingStore routing.Store, auditor audittools.Auditor) error {
 	logg.Info("Starting Hermes API server")
 
 	// Create API compositions
-	v1API := NewV1API(validator, storageInterface)
+	v1API := NewV1API(validator, storageInterface, routingStore, auditor)
 	versionAPI := NewVersionAPI(v1API.VersionData())
 	metricsAPI := NewMetricsAPI()
 
@@ -37,10 +38,10 @@ func Server(validator gopherpolicy.Validator, storageInterface storage.Storage) 
 	// Apply middleware
 	handler = InstrumentInflight(handler)
 
-	// Enable CORS support
+	// Enable CORS support — PUT and DELETE are required for the dataplane-config endpoints.
 	c := cors.New(cors.Options{
 		AllowedHeaders: []string{"X-Auth-Token", "Content-Type", "Accept"},
-		AllowedMethods: []string{"GET", "HEAD"},
+		AllowedMethods: []string{"GET", "HEAD", "PUT", "DELETE"},
 		MaxAge:         600,
 	})
 	handler = c.Handler(handler)
@@ -48,6 +49,5 @@ func Server(validator gopherpolicy.Validator, storageInterface storage.Storage) 
 	// Start HTTP server
 	listenAddress := viper.GetString("API.ListenAddress")
 
-	ctx := httpext.ContextWithSIGINT(context.Background(), 10*time.Second)
 	return httpext.ListenAndServeContext(ctx, listenAddress, handler)
 }

--- a/pkg/routing/interface.go
+++ b/pkg/routing/interface.go
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package routing
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrNotFound is returned by Store.Get when no config exists for a project.
+var ErrNotFound = errors.New("routing: config not found for project")
+
+// Store is the persistence interface for dataplane routing configuration.
+// The Postgres implementation is the production backend;
+// the Mock implementation is used in unit tests.
+//
+// All methods receive a context so they respect request cancellation.
+type Store interface {
+	// Get retrieves the config for a project.
+	// Returns ErrNotFound if no document exists; callers should treat that as
+	// the default disabled config rather than an error visible to the client.
+	Get(ctx context.Context, projectID string) (*DataplaneConfig, error)
+
+	// Upsert creates or replaces the config for a project.
+	Upsert(ctx context.Context, cfg DataplaneConfig) error
+
+	// Delete removes the config for a project.
+	// Returns (true, nil) if a config existed and was removed.
+	// Returns (false, nil) if no config existed (idempotent: not an error).
+	Delete(ctx context.Context, projectID string) (bool, error)
+}

--- a/pkg/routing/mock.go
+++ b/pkg/routing/mock.go
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package routing
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// Mock implements Store with in-memory storage for use in unit tests.
+type Mock struct {
+	mu      sync.RWMutex
+	configs map[string]DataplaneConfig
+}
+
+// NewMock creates an empty Mock store.
+func NewMock() *Mock {
+	return &Mock{configs: make(map[string]DataplaneConfig)}
+}
+
+// Get retrieves the config for a project.
+func (m *Mock) Get(_ context.Context, projectID string) (*DataplaneConfig, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cfg, ok := m.configs[projectID]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	c := cfg
+	return &c, nil
+}
+
+// Upsert creates or replaces the config for a project.
+func (m *Mock) Upsert(_ context.Context, cfg DataplaneConfig) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if cfg.UpdatedAt.IsZero() {
+		cfg.UpdatedAt = time.Now().UTC()
+	}
+	m.configs[cfg.ProjectID] = cfg
+	return nil
+}
+
+// Delete removes the config for a project. Idempotent.
+// Returns (true, nil) if a config existed and was removed; (false, nil) if none existed.
+func (m *Mock) Delete(_ context.Context, projectID string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	_, existed := m.configs[projectID]
+	delete(m.configs, projectID)
+	return existed, nil
+}
+
+// Ensure Mock implements Store.
+var _ Store = (*Mock)(nil)

--- a/pkg/routing/postgres.go
+++ b/pkg/routing/postgres.go
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+package routing
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/sapcc/go-bits/easypg"
+	"github.com/sapcc/go-bits/logg"
+	"github.com/sapcc/go-bits/osext"
+)
+
+// DBMigrations contains the SQL migrations for the dataplane_config table.
+// Keys must follow the golang-migrate filename convention.
+var DBMigrations = map[string]string{
+	"001_create_dataplane_config.up.sql": `
+		CREATE TABLE IF NOT EXISTS dataplane_config (
+			project_id    VARCHAR(64) PRIMARY KEY,
+			enabled       BOOLEAN     NOT NULL DEFAULT FALSE,
+			target_bucket TEXT        NOT NULL DEFAULT '',
+			updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			updated_by    VARCHAR(64) NOT NULL DEFAULT ''
+		);
+
+		-- Read-only role for log-router to consume config without write access.
+		-- The 'log-router' login role must exist in the database cluster;
+		-- it is provisioned by the hermes helm chart (postgres-ng seed).
+		DO $$
+		BEGIN
+			IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'log_router_reader') THEN
+				CREATE ROLE log_router_reader NOLOGIN;
+			END IF;
+		END
+		$$;
+		GRANT SELECT ON dataplane_config TO log_router_reader;
+	`,
+	"001_create_dataplane_config.down.sql": `
+		DROP TABLE IF EXISTS dataplane_config;
+		DROP ROLE IF EXISTS log_router_reader;
+	`,
+}
+
+// Postgres implements Store using a PostgreSQL database.
+type Postgres struct {
+	db *sql.DB
+}
+
+// NewPostgres connects to postgres using env-var based connection params and
+// runs any pending migrations. The env vars are:
+//
+//	HERMES_PG_HOSTNAME (default: localhost)
+//	HERMES_PG_PORT     (default: 5432)
+//	HERMES_PG_USERNAME (default: hermes)
+//	HERMES_PG_PASSWORD
+//	HERMES_PG_DBNAME   (default: hermes)
+//	HERMES_PG_CONNECTION_OPTIONS
+func NewPostgres() (*Postgres, error) {
+	dbURL, err := easypg.URLFrom(easypg.URLParts{
+		HostName:          osext.GetenvOrDefault("HERMES_PG_HOSTNAME", "localhost"),
+		Port:              osext.GetenvOrDefault("HERMES_PG_PORT", "5432"),
+		UserName:          osext.GetenvOrDefault("HERMES_PG_USERNAME", "hermes"),
+		Password:          osext.GetenvOrDefault("HERMES_PG_PASSWORD", ""),
+		ConnectionOptions: osext.GetenvOrDefault("HERMES_PG_CONNECTION_OPTIONS", ""),
+		DatabaseName:      osext.GetenvOrDefault("HERMES_PG_DBNAME", "hermes"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("routing: cannot build postgres URL: %w", err)
+	}
+	return NewPostgresFromURL(dbURL)
+}
+
+// NewPostgresFromURL connects to postgres at the given URL and runs migrations.
+// Useful in tests that provide a pre-built URL.
+func NewPostgresFromURL(dbURL url.URL) (*Postgres, error) {
+	db, err := easypg.Connect(dbURL, easypg.Configuration{
+		Migrations: DBMigrations,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("routing: cannot connect to postgres: %w", err)
+	}
+	db.SetMaxOpenConns(16)
+	db.SetMaxIdleConns(4)
+	logg.Info("routing: postgres connected and migrations applied")
+	return &Postgres{db: db}, nil
+}
+
+// Get retrieves the config for a project.
+func (p *Postgres) Get(ctx context.Context, projectID string) (*DataplaneConfig, error) {
+	var cfg DataplaneConfig
+	err := p.db.QueryRowContext(ctx,
+		`SELECT project_id, enabled, target_bucket, updated_at, updated_by
+		   FROM dataplane_config WHERE project_id = $1`,
+		projectID,
+	).Scan(&cfg.ProjectID, &cfg.Enabled, &cfg.TargetBucket, &cfg.UpdatedAt, &cfg.UpdatedBy)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("routing: cannot get config for project %s: %w", projectID, err)
+	}
+	return &cfg, nil
+}
+
+// Upsert creates or replaces the config for a project.
+func (p *Postgres) Upsert(ctx context.Context, cfg DataplaneConfig) error {
+	_, err := p.db.ExecContext(ctx,
+		`INSERT INTO dataplane_config (project_id, enabled, target_bucket, updated_at, updated_by)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (project_id) DO UPDATE SET
+		     enabled       = EXCLUDED.enabled,
+		     target_bucket = EXCLUDED.target_bucket,
+		     updated_at    = EXCLUDED.updated_at,
+		     updated_by    = EXCLUDED.updated_by`,
+		cfg.ProjectID, cfg.Enabled, cfg.TargetBucket, cfg.UpdatedAt, cfg.UpdatedBy,
+	)
+	if err != nil {
+		return fmt.Errorf("routing: cannot upsert config for project %s: %w", cfg.ProjectID, err)
+	}
+	return nil
+}
+
+// Delete removes the config for a project. Idempotent.
+// Returns (true, nil) if a row was deleted; (false, nil) if none existed.
+func (p *Postgres) Delete(ctx context.Context, projectID string) (bool, error) {
+	result, err := p.db.ExecContext(ctx,
+		`DELETE FROM dataplane_config WHERE project_id = $1`,
+		projectID,
+	)
+	if err != nil {
+		return false, fmt.Errorf("routing: cannot delete config for project %s: %w", projectID, err)
+	}
+	n, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("routing: cannot get rows affected after delete for project %s: %w", projectID, err)
+	}
+	return n > 0, nil
+}
+
+// Close releases the database connection pool.
+func (p *Postgres) Close() error {
+	return p.db.Close()
+}
+
+// Ensure Postgres implements Store.
+var _ Store = (*Postgres)(nil)

--- a/pkg/routing/types.go
+++ b/pkg/routing/types.go
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company
+// SPDX-License-Identifier: Apache-2.0
+
+// Package routing manages per-project dataplane routing configuration.
+// Hermez is the authoritative writer; log-router is a read-only consumer
+// via direct postgres SELECT (see docs/dataplane-config-read-contract.md).
+package routing
+
+import (
+	"time"
+
+	"github.com/sapcc/go-api-declarations/cadf"
+	"github.com/sapcc/go-bits/must"
+)
+
+// DataplaneConfig holds the routing configuration for a single project.
+// When Enabled is true, log-router routes dataplane events from Ceph RGW
+// into the project's TargetBucket in addition to the shared admin bucket.
+type DataplaneConfig struct {
+	ProjectID    string    `json:"project_id"`
+	Enabled      bool      `json:"enabled"`
+	TargetBucket string    `json:"target_bucket,omitempty"`
+	UpdatedAt    time.Time `json:"updated_at"`
+	UpdatedBy    string    `json:"updated_by"`
+}
+
+// DefaultDataplaneConfig returns the default (disabled) config for a project
+// that has no stored configuration. Callers should set ProjectID on the result.
+func DefaultDataplaneConfig(projectID string) DataplaneConfig {
+	return DataplaneConfig{
+		ProjectID: projectID,
+		Enabled:   false,
+	}
+}
+
+// Render implements the audittools.Target interface so DataplaneConfig can be
+// used directly in audittools.Event.Target. The full config is attached as JSON
+// so audit consumers can see exactly what was written.
+func (c DataplaneConfig) Render() cadf.Resource {
+	return cadf.Resource{
+		TypeURI:   "service/hermes/dataplane-config",
+		ID:        c.ProjectID,
+		ProjectID: c.ProjectID,
+		Attachments: []cadf.Attachment{
+			must.Return(cadf.NewJSONAttachment("payload", map[string]any{
+				"enabled":       c.Enabled,
+				"target_bucket": c.TargetBucket,
+			})),
+		},
+	}
+}

--- a/pkg/test/policy.json
+++ b/pkg/test/policy.json
@@ -1,4 +1,5 @@
 {
-  "event:list":     "@",
-  "event:show":     "@"
+  "event:list":              "@",
+  "event:show":              "@",
+  "dataplane_config:manage": "@"
 }


### PR DESCRIPTION
## Summary

- Adds `GET/PUT/DELETE /v1/projects/{project_id}/dataplane-config` endpoints for managing per-project log routing configuration (enabled flag + S3 target bucket)
- Introduces `pkg/routing` package: `Store` interface, Postgres implementation (`easypg`), in-memory mock, and `DataplaneConfig` type with CADF audit target rendering
- Wires `audittools.Auditor` from `main` through the API server; RabbitMQ delivery via `HERMES_AUDIT_RABBITMQ_*` env vars (production queue: `notifications.info` on `hermes-rabbitmq-notifications.hermes.svc`); falls back to `NullAuditor` with an `Error`-level log when unconfigured
- S3 bucket name validation: RFC-1123-subset (3–63 chars, lowercase/digits/hyphens, no leading/trailing hyphen, no consecutive hyphens)
- Cross-project access rejected at auth layer (403); storage errors obfuscated via `respondwith.ObfuscatedErrorText`
- `dataplane_config:manage` policy rule added (maps to `project_admin`)

## Test plan

- [ ] `make check` passes (0 lint issues, all tests green) — verified locally
- [ ] `TestDataplaneConfig_*` covers: GET default, GET existing, PUT success, PUT invalid bucket (5 cases incl. `--`), PUT enabled-missing-bucket, PUT unknown field, PUT content-type enforcement, DELETE+GET roundtrip, DELETE non-existent (idempotent, no audit event), cross-project 403 (GET/PUT/DELETE)
- [ ] Audit event assertions use `audittools.MockAuditor.ExpectEvents` with full structural diff — `Action`, `Outcome`, `Reason`, `RequestPath`, and `Target` (incl. JSON attachment) all verified
- [ ] Deploy-side: set `HERMES_AUDIT_RABBITMQ_QUEUE_NAME=notifications.info`, `HERMES_AUDIT_RABBITMQ_HOSTNAME=hermes-rabbitmq-notifications.hermes.svc`, credentials from vault `hermes/rabbitmq-user/notifications-default/user|password`